### PR TITLE
Add support for Json, JsonDocument, Yson types. Change default gorm serialization to YDB typing.

### DIFF
--- a/internal/dialect/dialect.go
+++ b/internal/dialect/dialect.go
@@ -92,7 +92,7 @@ func (d Dialector) Name() string {
 func (d Dialector) Initialize(db *gorm.DB) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-
+	schema.RegisterSerializer("json", DefaultYdbJSONSerializer{})
 	if d.Conn != nil {
 		db.ConnPool = d.Conn
 	} else {

--- a/internal/dialect/serializer.go
+++ b/internal/dialect/serializer.go
@@ -1,0 +1,41 @@
+package dialect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/ydb-platform/gorm-driver/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
+	"gorm.io/gorm/schema"
+	"reflect"
+	"strings"
+)
+
+// DefaultYdbJSONSerializer is implementation of default serializer in YDB format
+type DefaultYdbJSONSerializer struct{}
+
+// Scan the same as original JSONSerializer
+func (DefaultYdbJSONSerializer) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue interface{}) error {
+	return schema.JSONSerializer{}.Scan(ctx, field, dst, dbValue)
+}
+
+// Value marshalize the Go value in JSON and wraps it in YDB value type
+func (DefaultYdbJSONSerializer) Value(_ context.Context, field *schema.Field, _ reflect.Value, fieldValue interface{}) (interface{}, error) {
+	b, err := json.Marshal(fieldValue)
+	if err != nil {
+		return nil, err
+	}
+	tp := strings.ToLower(field.TagSettings["TYPE"])
+	switch tp {
+	case "json":
+		return types.JSONValueFromBytes(b), nil
+	case "jsondocument":
+		return types.JSONDocumentValueFromBytes(b), nil
+	case "yson":
+		//return types.YSONValueFromBytes(b), nil
+		return nil, xerrors.WithStacktrace(fmt.Errorf("Yson serialization not supported yet"))
+	default:
+		// По умолчанию — обычный Json
+		return nil, xerrors.WithStacktrace(fmt.Errorf("cant resolve serializer for field: '%v'", field))
+	}
+}

--- a/internal/dialect/serializer.go
+++ b/internal/dialect/serializer.go
@@ -21,7 +21,7 @@ func (DefaultYdbJSONSerializer) Scan(ctx context.Context, field *schema.Field, d
 	return schema.JSONSerializer{}.Scan(ctx, field, dst, dbValue)
 }
 
-// Value marshalize the Go value in JSON and wraps it in YDB value type
+// Value marshal the Go value in JSON and wraps it in YDB value type
 func (DefaultYdbJSONSerializer) Value(_ context.Context, field *schema.Field, _ reflect.Value, fieldValue interface{}) (interface{}, error) {
 	b, err := json.Marshal(fieldValue)
 	if err != nil {

--- a/internal/dialect/serializer.go
+++ b/internal/dialect/serializer.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/ydb-platform/gorm-driver/internal/xerrors"
-	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
-	"gorm.io/gorm/schema"
 	"reflect"
 	"strings"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
+	"gorm.io/gorm/schema"
+
+	"github.com/ydb-platform/gorm-driver/internal/xerrors"
 )
 
 // DefaultYdbJSONSerializer is implementation of default serializer in YDB format

--- a/internal/dialect/type.go
+++ b/internal/dialect/type.go
@@ -107,6 +107,21 @@ func parseField(f *schema.Field) (gorm.ColumnType, types.Type, error) {
 		return wrapType(types.TypeBytes)
 	case schema.Time:
 		return wrapType(types.TypeTimestamp)
+	case "json": // considering implementation of Json field via datatypes.JSON type from "gorm.io/datatypes" package
+		if f.TagSettings["TYPE"] == "" {
+			return nil, nil, xerrors.WithStacktrace(fmt.Errorf("empty type tag. Possible values: [\"Json\",\"JsonDocument\", \"Yson\"]"))
+		}
+		switch f.TagSettings["TYPE"] {
+		case "Json":
+			return wrapType(types.TypeJSON)
+		case "JsonDocument":
+			return wrapType(types.TypeJSONDocument)
+		case "Yson":
+			return wrapType(types.TypeYSON)
+		default:
+			return nil, nil, xerrors.WithStacktrace(fmt.Errorf("unsupported json type '%s'. Possible values: "+
+				"[\"Json\", \"JsonDocument\", \"Yson\"]", f.Tag))
+		}
 	default:
 		return nil, nil, xerrors.WithStacktrace(fmt.Errorf("unsupported data type '%s'", f.DataType))
 	}

--- a/internal/dialect/type.go
+++ b/internal/dialect/type.go
@@ -70,6 +70,7 @@ func parseField(f *schema.Field) (gorm.ColumnType, types.Type, error) {
 		return ct, t, err
 	}
 	if tp, ok := f.TagSettings["TYPE"]; ok {
+		tp = strings.TrimSpace(tp)
 		switch strings.ToLower(tp) {
 		case "json":
 			if f.Serializer == nil {

--- a/internal/dialect/type_test.go
+++ b/internal/dialect/type_test.go
@@ -296,7 +296,7 @@ func Test_parseField(t *testing.T) { //nolint:funlen
 		{
 			field: &schema.Field{
 				DBName:   uuid.New().String(),
-				DataType: "json",
+				DataType: "Json",
 			},
 			isError:   true,
 			typesType: types.TypeJSON,

--- a/internal/dialect/type_test.go
+++ b/internal/dialect/type_test.go
@@ -82,6 +82,36 @@ func Test_schemaFieldToColumnType(t *testing.T) { //nolint:funlen
 				Size:     32,
 			},
 			typesType: types.TypeInt32,
+		}, {
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "Json",
+				},
+			},
+			typesType: types.TypeJSON,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "JsonDocument",
+				},
+			},
+
+			typesType: types.TypeJSONDocument,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "Yson",
+				},
+			},
+			typesType: types.TypeYSON,
 		},
 	}
 	for _, tt := range tests {
@@ -220,6 +250,56 @@ func Test_parseField(t *testing.T) { //nolint:funlen
 				DataType: schema.Time,
 			},
 			typesType: types.TypeTimestamp,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "Json",
+				},
+			},
+			typesType: types.TypeJSON,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "JsonDocument",
+				},
+			},
+
+			typesType: types.TypeJSONDocument,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "Yson",
+				},
+			},
+			typesType: types.TypeYSON,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+				TagSettings: map[string]string{
+					"TYPE": "UnknownFormat",
+				},
+			},
+			isError:   true,
+			typesType: types.TypeJSON,
+		},
+		{
+			field: &schema.Field{
+				DBName:   uuid.New().String(),
+				DataType: "json",
+			},
+			isError:   true,
+			typesType: types.TypeJSON,
 		},
 		{
 			field:   &schema.Field{},


### PR DESCRIPTION
Реализовал маппинг shema.Field в типы YDB в соответствии с SDK.

Добавил сериализатор, который приводит к необходимым типам для ydb.types. Он регистрируется при инициализации диалекта.

```go
// DefaultYdbJSONSerializer is implementation of default serializer in YDB format
type DefaultYdbJSONSerializer struct{}

// Scan the same as original JSONSerializer
func (DefaultYdbJSONSerializer) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue interface{}) error {
	return schema.JSONSerializer{}.Scan(ctx, field, dst, dbValue)
}

// Value marshalize the Go value in JSON and wraps it in YDB value type
func (DefaultYdbJSONSerializer) Value(_ context.Context, field *schema.Field, _ reflect.Value, fieldValue interface{}) (interface{}, error) {
	b, err := json.Marshal(fieldValue)
	if err != nil {
		return nil, err
	}
	tp := strings.ToLower(field.TagSettings["TYPE"])
	switch tp {
	case "json":
		return types.JSONValueFromBytes(b), nil
	case "jsondocument":
		return types.JSONDocumentValueFromBytes(b), nil
	case "yson":
		//return types.YSONValueFromBytes(b), nil
		return nil, xerrors.WithStacktrace(fmt.Errorf("Yson serialization not supported yet"))
	default:
		// По умолчанию — обычный Json
		return nil, xerrors.WithStacktrace(fmt.Errorf("cant resolve serializer for field: '%v'", field))
	}
}
```
С сериализацией Yson не получилось.

немного покрыл тестами маппинг полей.

```go
type TetsModel struct {
	ID          string                 `gorm:"column:series_id;primarykey;not null"`
	JsonField   map[string]interface{} `gorm:"column:test_json;type:Yson"` // миграция пройдет, сериализация не сработает (можно написать свой сериализатор и зарегистрировать не меняя библиотеку)
}
```
```go
type TetsModel struct {
	ID          string                 `gorm:"column:series_id;primarykey;not null"`
	JsonField   map[string]interface{} `gorm:"column:test_json;type:Json"` 
	JsonField2   map[string]interface{} `gorm:"column:test_json2;type:Json;serializer:json"`
// эквивалентные поля (по умолчанию пытаемся подставить DefaultYdbJsonSerializer)
}
```
```go
type TetsModel struct {
	ID          string                 `gorm:"column:series_id;primarykey;not null"`
	JsonField   map[string]interface{} `gorm:"column:test_json;type:JsonDocument"` 
	JsonField2   map[string]interface{} `gorm:"column:test_json2;type: JsonDocument;serializer:json"`
// эквивалентные поля (по умолчанию пытаемся подставить DefaultYdbJsonSerializer)
}
```